### PR TITLE
Adds Problem Size Support to CMake Tester

### DIFF
--- a/lnt/tests/test_suite.py
+++ b/lnt/tests/test_suite.py
@@ -621,6 +621,15 @@ class TestSuiteTest(BuiltinTest):
             if 'TEST_SUITE_RUN_TYPE' not in defs:
                 defs['TEST_SUITE_RUN_TYPE'] = 'ref'
 
+        # Problem Size
+        if self.opts.test_size != "regular":
+            if self.opts.test_size == "large":
+                defs["LARGE_PROBLEM_SIZE"] = "On"
+            elif self.opts.test_size == "small":
+                defs["SMALL_PROBLEM_SIZE"] = "On"
+            else:
+                pass
+
         for item in self.opts.cmake_defines + extra_cmake_defs:
             k, v = item.split('=', 1)
             # make sure the overriding of the settings above also works


### PR DESCRIPTION
The CMake Tester until this point had no support for changing the test input size based on test runner arguments. This adds that support.

The CMake configuration (and Makefiles) use `LARGE_PROBLEM_SIZE` and `SMALL_PROBLEM_SIZE` variables to change the input arguments and reference outputs to check against, so we just make sure they are set if someone has passed a problem size argument.