### PR TITLE
Add support for gathering code size metrics on linux

### DIFF
--- a/lnt/tests/test_suite.py
+++ b/lnt/tests/test_suite.py
@@ -815,7 +815,8 @@ class TestSuiteTest(BuiltinTest):
             'score': 'score',
             'hash': 'hash',
             'link_time': 'compile',
-            'size.__text': 'code_size'
+            'size.__text': 'code_size', # Code size in Mach-O executables (Mac)
+            'size..text': 'code_size',  # Code size in ELF executables (Linux)
         }
         LIT_METRIC_CONV_FN = {
             'compile_time': float,
@@ -823,7 +824,8 @@ class TestSuiteTest(BuiltinTest):
             'score': float,
             'hash': str,
             'link_time': float,
-            'size.__text': float,
+            'size.__text': float, # Code size in Mach-O executables (Mac)
+            'size..text': float,  # Code size in ELF executables (Linux)
         }
 
         # We don't use the test info, currently.


### PR DESCRIPTION
This is the most annoying bug by omission, but I've traced it. 

Turns out they record lots of metrics, but because section names are different on Mach-O (the Mac executable format) to the section names on ELF (the linux executable format), they never submit the metrics for code size on linux. 

I can't guarantee the section sizes are the same across platforms - the ELF executables I've looked at seem to have many more sections than their equivalent mach-o executables, but at least text should be the one changing compile-to-compile, and should not contain any debug information.

I'm not worried about having two mappings to code_size, if there were ever both, one would overwrite the other, I think I'm just hoping no clang-produced benchmark executable has both a `.text` section and a `__text` section. Checking the logs from benchmarking already, this seems to be the case for our benchmarks so far. 

Once this is merged, I'll need to update my docker benchmarking image, and then go from there. This should probably go upstream to LNT itself too, eventually.