### PR TITLE
Try to import parse_requirements from pip._internal.req too.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ try:
 except ImportError:
     # The req module has been moved to pip._internal in the 10 release.
     from pip._internal.req import parse_requirements
-from pip.req import parse_requirements
 import lnt
 import os
 from sys import platform as _platform

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,8 @@
+try:
+    from pip.req import parse_requirements
+except ImportError:
+    # The req module has been moved to pip._internal in the 10 release.
+    from pip._internal.req import parse_requirements
 from pip.req import parse_requirements
 import lnt
 import os


### PR DESCRIPTION
Pip's internal modules have been moved to pip._internal in
95bcf8c5f6394298035a7332c441868f3b0169f4 [1], which is part of the 10.0.0b2
release.

Refer upstream commit
https://github.com/llvm-mirror/lnt/commit/db4ffb66f3f2868219f9af6f7c5bc8568afcd034